### PR TITLE
Fix input change problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.stack-work
 dist
 cabal-dev
 *.o
@@ -10,3 +11,4 @@ cabal-dev
 cabal.sandbox.config
 add.sh
 *.*~
+/TAGS

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,7 +24,7 @@ packages:
   extra-dep: true
 - location:
     git: git@github.com:plow-technologies/ghcjs-vdom.git
-    commit: a9d8073be232ac39c1542957ff7e9d6c877b4188
+    commit: 4bab395f9454383962ad86f1d00334b63ee8acee
   extra-dep: true
 
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,41 @@
+resolver: lts-5.12
+compiler: ghcjs-0.2.0.20160414_ghc-7.10.3
+compiler-check: match-exact
+setup-info:
+  ghcjs:
+    source:
+      ghcjs-0.2.0.20160414_ghc-7.10.3:
+        url: https://s3.amazonaws.com/ghcjs/ghcjs-0.2.0.20160414_ghc-7.10.3.tar.gz
+        sha1: 6d6f307503be9e94e0c96ef1308c7cf224d06be3
+
+packages:
+- '.'
+- location:
+    git: git@github.com:plow-technologies/valentine.git
+    commit: 40add31066cef8decd43787685b86f84bc5f414a
+  extra-dep: true
+- location:
+    git: git@github.com:plow-technologies/stm-notify.git
+    commit: f047ee8c82993e79f7241688748e220affda6a73
+  extra-dep: true
+- location:
+    git: git@github.com:ghcjs/ghcjs-ffiqq.git
+    commit: b52338c2dcd3b0707bc8aff2e171411614d4aedb
+  extra-dep: true
+- location:
+    git: git@github.com:plow-technologies/ghcjs-vdom.git
+    commit: a9d8073be232ac39c1542957ff7e9d6c877b4188
+  extra-dep: true
+
+extra-deps:
+- special-keys-0.1.0.3
+- th-lift-instances-0.1.10
+- th-lift-0.7.6
+- path-pieces-0.2.1
+- reflection-2.1.2
+- safe-0.3.9
+- transformers-compat-0.5.1.4
+- utf8-string-1.0.1.1
+- aeson-serialize-0.0.0
+- network-info-0.2.0.8
+- prelude-extras-0.4.0.3


### PR DESCRIPTION
Merge @smurphy8 fixes for input problem. This serves as documentation.

The issue is that when iterating sequence to be displayed into multiple input boxes, deleting any of the input box causes the value not to be updated on the UI (but updated in DOM). This is due to `Property` is rendered in vdom as an attribute `elem.attribute.property` instead of `elem.property`. So there isn't  a way to set `elem.defaultValue` correctly. 

Some useful link:
- https://github.com/Matt-Esch/virtual-dom/blob/dcb8a14e96a5f78619510071fd39a5df52d381b7/docs/vnode.md

> If an input element is reset, its value will be returned to its value set in properties.attributes.value. If you've set the value using properties.value, this will not happen. However, you may set properties.defaultValue to get the desired result.

- http://stackoverflow.com/questions/6003819/properties-and-attributes-in-html
- https://www.w3.org/TR/2011/WD-html5-20110113/the-input-element.html

>  Each input element has a boolean dirty value flag. The dirty value flag must be initially set to false when the element is created, and must be set to true whenever the user interacts with the control in a way that changes the value.
> The value content attribute gives the default value of the input element. When the value content attribute is added, set, or removed, if the control's dirty value flag is false, the user agent must set the value of the element to the value of the value content attribute, if there is one, or the empty string otherwise, and then run the current value sanitization algorithm, if one is defined.

Details:
![anim](https://cloud.githubusercontent.com/assets/913103/18029489/cb4271b0-6ccb-11e6-858e-3e23dccdf886.gif)
